### PR TITLE
quickfix assignment command

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/npc/AssignmentCommand.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/npc/AssignmentCommand.java
@@ -65,7 +65,7 @@ public class AssignmentCommand extends AbstractCommand {
         dScript script = scriptEntry.getdObject("script");
 
         // Report to dB
-        dB.report(scriptEntry, getName(), aH.debugObj("action", scriptEntry.getObject("action")) + script.debug());
+        dB.report(scriptEntry, getName(), aH.debugObj("action", scriptEntry.getObject("action")) + (script != null ? script.debug() : ""));
 
         // Perform desired action
         if (scriptEntry.getObject("action").equals(Action.SET)) {


### PR DESCRIPTION
`- assignment [set/remove] (script:<name>)`

`- assignment remove` breaks with an NullPointer, because if the `script:` isn't set, then line 65 fills with null,
this leads to an NullPointer in line 68, when debug is called. http://old.mcmonkey.org/paste/47327#33

