### PR TITLE
Improve p@player.open_inventory tag

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/objects/dPlayer.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/objects/dPlayer.java
@@ -1521,7 +1521,7 @@ public class dPlayer implements dObject, Adjustable {
         // inventory, this returns the player's inventory.
         // -->
         if (attribute.startsWith("open_inventory")) {
-            return new dInventory(getPlayerEntity().getOpenInventory().getTopInventory())
+            return dInventory.mirrorBukkitInventory(getPlayerEntity().getOpenInventory().getTopInventory())
                     .getAttribute(attribute.fulfill(1));
         }
 


### PR DESCRIPTION
this change allow me to get what current inventory script that the player open.
previously it only return a new generic type inventory.