### PR TITLE
improve death event

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/events/entity/EntityDeathScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/entity/EntityDeathScriptEvent.java
@@ -245,6 +245,9 @@ public class EntityDeathScriptEvent extends BukkitScriptEvent implements Listene
             }
 
         }
+        else if (livingEntity.getKiller() != null) {
+        	damager = new dPlayer(livingEntity.getKiller());
+        }
 
         message = null;
         inventory = null;
@@ -286,8 +289,8 @@ public class EntityDeathScriptEvent extends BukkitScriptEvent implements Listene
             }
         }
         if (subEvent != null) {
-            ((PlayerDeathEvent) event).setKeepInventory(keep_inv);
-            ((PlayerDeathEvent) event).setKeepLevel(keep_level);
+            subEvent.setKeepInventory(keep_inv);
+            subEvent.setKeepLevel(keep_level);
             if (message != null) {
                 subEvent.setDeathMessage(message.asString());
             }


### PR DESCRIPTION
Your cleanup got lot better than mine.

Actually it seems like you forgot this else if. `getKiller` fills with the last player that damaged this entity, to match the damager also in a case he didn't do the "final hit". (fire, falldamage, ... )

Guess these 2 type-casts can be spared too.