### PR TITLE
because let's commit before we test

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/events/entity/EntityDeathScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/entity/EntityDeathScriptEvent.java
@@ -243,10 +243,10 @@ public class EntityDeathScriptEvent extends BukkitScriptEvent implements Listene
                     damager = damageEntity.getDenizenObject();
                 }
             }
+            else if (livingEntity.getKiller() != null) {
+            	damager = new dPlayer(livingEntity.getKiller());
+            }
 
-        }
-        else if (livingEntity.getKiller() != null) {
-        	damager = new dPlayer(livingEntity.getKiller());
         }
 
         message = null;


### PR DESCRIPTION
My else if won't have it's effect at the current position.
It's `instanceof EntityDamageByEntityEvent` that will be _false_ when death caused by environmental sources.