### PR TITLE
improve inventory performane

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/objects/dInventory.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/objects/dInventory.java
@@ -435,7 +435,7 @@ public class dInventory implements dObject, Notable, Adjustable {
         String myItem = CoreUtilities.toLowerCase(item.getFullString());
         for (int i = 0; i < inventory.getSize(); i++) {
             ItemStack is = inventory.getItem(i);
-            if (is == null) {
+            if (is == null || item.getMaterial().getMaterial() != is.getType()) {
                 continue;
             }
             is = is.clone();


### PR DESCRIPTION
Hey.
For me, this little change speeded up the inventory.contains[] check by 600% .
_without: 2100 ms for 1000 actions
with:        330 ms for 1000 actions_

The idea is to simply check the material reference before doing all further Strings checks and stuff.

Actually you might look for unwanted side effects of this change, which I might be unaware of.
