### PR TITLE
improve event performance

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
@@ -113,7 +113,11 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
         }
         item = new dItem(item.getItemStack().clone());
         item.setAmount(1);
-        if (CoreUtilities.toLowerCase(item.identifyNoIdentifier()).equals(comparedto)) {
+        dMaterial material = dMaterial.valueOf(comparedto);
+        if (material == null || item.getMaterial().getMaterial() != material.getMaterial()) {
+        	return false;
+        }
+        else if (CoreUtilities.toLowerCase(item.identifyNoIdentifier()).equals(comparedto)) {
             return true;
         }
         else if (CoreUtilities.toLowerCase(item.identifyMaterialNoIdentifier()).equals(comparedto)) {
@@ -134,7 +138,11 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
             return false;
         }
         comparedto = CoreUtilities.toLowerCase(comparedto);
-        if (comparedto.equals("block") || comparedto.equals("material")) {
+        dMaterial material = dMaterial.valueOf(comparedto);
+        if (material == null || mat.getMaterial() != material.getMaterial()) {
+        	return false;
+        }
+        else if (comparedto.equals("block") || comparedto.equals("material")) {
             return true;
         }
         else if (CoreUtilities.toLowerCase(mat.realName()).equals(comparedto)) {

--- a/plugin/src/main/java/net/aufdemrand/denizen/events/player/PlayerClicksBlockScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/player/PlayerClicksBlockScriptEvent.java
@@ -101,7 +101,7 @@ public class PlayerClicksBlockScriptEvent extends BukkitScriptEvent implements L
                 dB.echoError("Invalid WITH item in " + getName() + " for '" + s + "' in " + scriptContainer.getName());
                 return false;
             }
-            if (held == null || !tryItem(held, with)) {
+            if (!tryItem(held, with)) {
                 return false;
             }
         }


### PR DESCRIPTION
Hey. As I digged into dEvents, i endet with these simple improvements.

**simple item drop:**
_without: 0.21%	   1.91%	  0.01 s	     0.95 ms
with: 0.03%	   0.35%	  0.00 s	     0.18 ms_

**written book drop:**
_without: 1.02%	  58.65%	  0.03 s	    29.32 ms
with: 0.16%	   1.12%	  0.01 s	     0.56 ms_

**placing of stone:**
_without: 0.29%	   2.35%	  0.02 s	     1.17 ms
with: 0.05%	   0.48%	  0.00 s	     0.24 ms_

So, for default items, it can speed up events by 100-400% depending on items and events.

The idea is again, to skip all further checks, when the Material reference doesn't match.

It should affect all events, as they use tryItem/tryMaterial.
(i also skipped this null check in PlayerClicksBlock, as tryItem already checks for null)

Yet i haven't found negative side effects of the changes, you may take still a closer look.

