### PR TITLE
improve script events v2

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
@@ -113,7 +113,11 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
         }
         item = new dItem(item.getItemStack().clone());
         item.setAmount(1);
-        if (CoreUtilities.toLowerCase(item.identifyNoIdentifier()).equals(comparedto)) {
+        dMaterial material = dMaterial.valueOf(comparedto);
+        if (material == null || item.getMaterial().getMaterial() != material.getMaterial()) {
+        	return false;
+        }
+        else if (CoreUtilities.toLowerCase(item.identifyNoIdentifier()).equals(comparedto)) {
             return true;
         }
         else if (CoreUtilities.toLowerCase(item.identifyMaterialNoIdentifier()).equals(comparedto)) {
@@ -134,7 +138,11 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
             return false;
         }
         comparedto = CoreUtilities.toLowerCase(comparedto);
-        if (comparedto.equals("block") || comparedto.equals("material")) {
+        dMaterial material = dMaterial.valueOf(comparedto);
+        if (material == null || mat.getMaterial() != material.getMaterial()) {
+        	return false;
+        }
+        else if (comparedto.equals("block") || comparedto.equals("material")) {
             return true;
         }
         else if (CoreUtilities.toLowerCase(mat.realName()).equals(comparedto)) {

--- a/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
@@ -112,7 +112,7 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
         else if (comparedto.equals("potion") && CoreUtilities.toLowerCase(item.getItemStack().getType().name()).contains("potion")) {
             return true;
         }
-        Material material = Material.getMaterial(comparedto);
+        Material material = Material.getMaterial(comparedto.toUpperCase());
         if (material == null || item.getMaterial().getMaterial() != material) {
         	return false;
         }
@@ -142,7 +142,7 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
         if (comparedto.equals("block") || comparedto.equals("material")) {
             return true;
         }
-        Material material = Material.getMaterial(comparedto);
+        Material material = Material.getMaterial(comparedto.toUpperCase());
         if (material == null || mat.getMaterial() != material) {
         	return false;
         }

--- a/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/BukkitScriptEvent.java
@@ -6,6 +6,7 @@ import net.aufdemrand.denizencore.events.ScriptEvent;
 import net.aufdemrand.denizencore.scripts.containers.ScriptContainer;
 import net.aufdemrand.denizencore.utilities.CoreUtilities;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.Projectile;
@@ -108,16 +109,16 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
         if (comparedto.equals("item")) {
             return true;
         }
-        if (comparedto.equals("potion") && CoreUtilities.toLowerCase(item.getItemStack().getType().name()).contains("potion")) {
+        else if (comparedto.equals("potion") && CoreUtilities.toLowerCase(item.getItemStack().getType().name()).contains("potion")) {
             return true;
+        }
+        Material material = Material.getMaterial(comparedto);
+        if (material == null || item.getMaterial().getMaterial() != material) {
+        	return false;
         }
         item = new dItem(item.getItemStack().clone());
         item.setAmount(1);
-        dMaterial material = dMaterial.valueOf(comparedto);
-        if (material == null || item.getMaterial().getMaterial() != material.getMaterial()) {
-        	return false;
-        }
-        else if (CoreUtilities.toLowerCase(item.identifyNoIdentifier()).equals(comparedto)) {
+        if (CoreUtilities.toLowerCase(item.identifyNoIdentifier()).equals(comparedto)) {
             return true;
         }
         else if (CoreUtilities.toLowerCase(item.identifyMaterialNoIdentifier()).equals(comparedto)) {
@@ -138,12 +139,12 @@ public abstract class BukkitScriptEvent extends ScriptEvent {
             return false;
         }
         comparedto = CoreUtilities.toLowerCase(comparedto);
-        dMaterial material = dMaterial.valueOf(comparedto);
-        if (material == null || mat.getMaterial() != material.getMaterial()) {
-        	return false;
-        }
-        else if (comparedto.equals("block") || comparedto.equals("material")) {
+        if (comparedto.equals("block") || comparedto.equals("material")) {
             return true;
+        }
+        Material material = Material.getMaterial(comparedto);
+        if (material == null || mat.getMaterial() != material) {
+        	return false;
         }
         else if (CoreUtilities.toLowerCase(mat.realName()).equals(comparedto)) {
             return true;

--- a/plugin/src/main/java/net/aufdemrand/denizen/events/player/PlayerClicksBlockScriptEvent.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/events/player/PlayerClicksBlockScriptEvent.java
@@ -101,7 +101,7 @@ public class PlayerClicksBlockScriptEvent extends BukkitScriptEvent implements L
                 dB.echoError("Invalid WITH item in " + getName() + " for '" + s + "' in " + scriptContainer.getName());
                 return false;
             }
-            if (held == null || !tryItem(held, with)) {
+            if (!tryItem(held, with)) {
                 return false;
             }
         }


### PR DESCRIPTION
Aight. _on player clicks block_ didn't work in my last PR, as the new checks were before _.equals("block")_, 
    so I changed the order here to fix that.

Working with Material.getMaterial() directly seems even faster, as it uses final/static references to lookup (dMaterial iterates with String checks instead).

**placing of stone:**
_without: 0.29%	2.35%	0.02 s	1.17 ms
last PR: 0.05%	0.48%	0.00 s	0.24 ms
this PR: 0.02%	   0.14%	  0.00 s	     0.07 ms_

You may look again, for possible conflicts ?