### PR TITLE
Fix spawn command

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -3755,7 +3755,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         // - spawn creeper|creeper|creeper|creeper|creeper <npc.location> persistent
         // -->
         registerCoreMember(SpawnCommand.class,
-                "SPAWN", "spawn [<entity>|...] [<location>] (target:<entity>) (persistent)", 2);
+                "SPAWN", "spawn [<entity>|...] (<location>) (target:<entity>) (persistent)", 1);
 
 
         // <--[command]


### PR DESCRIPTION
Spawn expects at least two arguments - despite this, there is existing code to default to the player/npc's location.

This has the effect of failing on a call such as:
`- spawn creeper`
But successfully spawning an entity on a call such as:
`- spawn creeper run_java`
Even though no location was provided.

This small change fixes this