### PR TITLE
Fix shield color

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/objects/properties/item/ItemBaseColor.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/objects/properties/item/ItemBaseColor.java
@@ -43,6 +43,9 @@ public class ItemBaseColor implements Property {
     dItem item;
 
     private DyeColor getBaseColor() {
+        if (!item.getItemStack().hasItemMeta()) {  // shield is uncolored
+            return null;
+        }
         ItemMeta itemMeta = item.getItemStack().getItemMeta();
         if (itemMeta instanceof BlockStateMeta) {
             return ((Banner) ((BlockStateMeta) itemMeta).getBlockState()).getBaseColor();


### PR DESCRIPTION
This fixes https://github.com/DenizenScript/Denizen-For-Bukkit/issues/1817

hasItemMeta() is false when no color is set, and true when a color is set.
When meta is created in the lines below, the default color is automatically set to BLACK,
so the check runs before that.

debug with fix: http://old.mcmonkey.org/paste/50034
