### PR TITLE
Fix advancement/toast commands in 1.13, use dItem icon

### DIFF
--- a/nmshandler/src/main/java/net/aufdemrand/denizen/nms/util/Advancement.java
+++ b/nmshandler/src/main/java/net/aufdemrand/denizen/nms/util/Advancement.java
@@ -1,7 +1,7 @@
 package net.aufdemrand.denizen.nms.util;
 
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
 
 public class Advancement {
 
@@ -10,8 +10,7 @@ public class Advancement {
     public boolean temporary;
     public NamespacedKey key;
     public NamespacedKey parent;
-    public Material iconMaterial;
-    public byte iconData;
+    public ItemStack icon;
     public String title;
     public String description;
     public NamespacedKey background;
@@ -25,14 +24,13 @@ public class Advancement {
 
     public boolean registered;
 
-    public Advancement(boolean temporary, NamespacedKey key, NamespacedKey parent, Material iconMaterial,
-                       byte iconData, String title, String description, NamespacedKey background, Frame frame,
+    public Advancement(boolean temporary, NamespacedKey key, NamespacedKey parent, ItemStack icon,
+                       String title, String description, NamespacedKey background, Frame frame,
                        boolean toast, boolean announceToChat, boolean hidden, float xOffset, float yOffset) {
         this.temporary = temporary;
         this.key = key;
         this.parent = parent;
-        this.iconMaterial = iconMaterial;
-        this.iconData = iconData;
+        this.icon = icon;
         this.title = title;
         this.description = description;
         this.background = background;

--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/BukkitCommandRegistry.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/BukkitCommandRegistry.java
@@ -122,7 +122,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
 
         // <--[command]
         // @Name Advancement
-        // @Syntax advancement [id:<name>] (delete/grant:<players>/revoke:<players>/{create}) (parent:<name>) (icon:<material>) (title:<text>) (description:<text>) (background:<key>) (frame:<type>) (toast:<boolean>) (announce:<boolean>) (hidden:<boolean>) (x:<offset>) (y:<offset>)
+        // @Syntax advancement [id:<name>] (delete/grant:<players>/revoke:<players>/{create}) (parent:<name>) (icon:<item>) (title:<text>) (description:<text>) (background:<key>) (frame:<type>) (toast:<boolean>) (announce:<boolean>) (hidden:<boolean>) (x:<offset>) (y:<offset>)
         // @Required 1
         // @Stable stable
         // @Short Controls a custom advancement.
@@ -168,7 +168,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         // -->
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_12_R1)) {
             registerCoreMember(AdvancementCommand.class,
-                    "ADVANCEMENT", "advancement [id:<name>] (delete/grant:<players>/revoke:<players>/{create}) (parent:<name>) (icon:<material>) (title:<text>) (description:<text>) (background:<key>) (frame:<type>) (toast:<boolean>) (announce:<boolean>) (hidden:<boolean>)", 1);
+                    "ADVANCEMENT", "advancement [id:<name>] (delete/grant:<players>/revoke:<players>/{create}) (parent:<name>) (icon:<item>) (title:<text>) (description:<text>) (background:<key>) (frame:<type>) (toast:<boolean>) (announce:<boolean>) (hidden:<boolean>)", 1);
         }
 
         // <--[command]
@@ -4149,7 +4149,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
 
         // <--[command]
         // @Name Toast
-        // @Syntax toast [<text>] (targets:<player>|...) (icon:<material>) (frame:<name>)
+        // @Syntax toast [<text>] (targets:<player>|...) (icon:<item>) (frame:<name>)
         // @Required 1
         // @Stable stable
         // @Short Shows the player a custom advancement toast.
@@ -4180,7 +4180,7 @@ public class BukkitCommandRegistry extends CommandRegistry {
         // -->
         if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_12_R1)) {
             registerCoreMember(ToastCommand.class,
-                    "TOAST", "toast [<text>] (targets:<player>|...) (icon:<material>) (frame:<name>)", 1);
+                    "TOAST", "toast [<text>] (targets:<player>|...) (icon:<item>) (frame:<name>)", 1);
         }
 
         // <--[command]

--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/player/AdvancementCommand.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/player/AdvancementCommand.java
@@ -3,7 +3,7 @@ package net.aufdemrand.denizen.scripts.commands.player;
 import net.aufdemrand.denizen.nms.NMSHandler;
 import net.aufdemrand.denizen.nms.interfaces.AdvancementHelper;
 import net.aufdemrand.denizen.nms.util.Advancement;
-import net.aufdemrand.denizen.objects.dMaterial;
+import net.aufdemrand.denizen.objects.dItem;
 import net.aufdemrand.denizen.objects.dPlayer;
 import net.aufdemrand.denizen.utilities.DenizenAPI;
 import net.aufdemrand.denizen.utilities.debugging.dB;
@@ -15,6 +15,7 @@ import net.aufdemrand.denizencore.objects.dList;
 import net.aufdemrand.denizencore.scripts.ScriptEntry;
 import net.aufdemrand.denizencore.scripts.commands.AbstractCommand;
 import net.aufdemrand.denizencore.utilities.CoreUtilities;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 
@@ -57,8 +58,8 @@ public class AdvancementCommand extends AbstractCommand {
             }
             else if (!scriptEntry.hasObject("icon")
                     && arg.matchesPrefix("icon", "i")
-                    && arg.matchesArgumentType(dMaterial.class)) {
-                scriptEntry.addObject("icon", arg.asType(dMaterial.class));
+                    && arg.matchesArgumentType(dItem.class)) {
+                scriptEntry.addObject("icon", arg.asType(dItem.class));
             }
             else if (!scriptEntry.hasObject("title")
                     && arg.matchesPrefix("title", "text", "t")) {
@@ -111,7 +112,7 @@ public class AdvancementCommand extends AbstractCommand {
             throw new InvalidArgumentsException("Must specify an ID!");
         }
 
-        scriptEntry.defaultObject("icon", dMaterial.AIR);
+        scriptEntry.defaultObject("icon", new dItem(Material.AIR));
         scriptEntry.defaultObject("title", new Element(""));
         scriptEntry.defaultObject("description", new Element(""));
         scriptEntry.defaultObject("background", new Element("minecraft:textures/gui/advancements/backgrounds/stone.png"));
@@ -133,7 +134,7 @@ public class AdvancementCommand extends AbstractCommand {
         Element delete = scriptEntry.getElement("delete");
         dList grant = scriptEntry.getdObject("grant");
         dList revoke = scriptEntry.getdObject("revoke");
-        dMaterial icon = scriptEntry.getdObject("icon");
+        dItem icon = scriptEntry.getdObject("icon");
         Element title = scriptEntry.getElement("title");
         Element description = scriptEntry.getElement("description");
         Element background = scriptEntry.getElement("background");
@@ -180,7 +181,7 @@ public class AdvancementCommand extends AbstractCommand {
             }
 
             final Advancement advancement = new Advancement(false, key, parentKey,
-                    icon.getMaterial(), icon.getData(), title.asString(), description.asString(),
+                    icon.getItemStack(), title.asString(), description.asString(),
                     backgroundKey, Advancement.Frame.valueOf(frame.asString().toUpperCase()),
                     toast.asBoolean(), announce.asBoolean(), hidden.asBoolean(), x.asFloat(), y.asFloat());
 

--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/player/ToastCommand.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/commands/player/ToastCommand.java
@@ -4,7 +4,7 @@ import net.aufdemrand.denizen.BukkitScriptEntryData;
 import net.aufdemrand.denizen.nms.NMSHandler;
 import net.aufdemrand.denizen.nms.interfaces.AdvancementHelper;
 import net.aufdemrand.denizen.nms.util.Advancement;
-import net.aufdemrand.denizen.objects.dMaterial;
+import net.aufdemrand.denizen.objects.dItem;
 import net.aufdemrand.denizen.objects.dPlayer;
 import net.aufdemrand.denizen.utilities.DenizenAPI;
 import net.aufdemrand.denizen.utilities.debugging.dB;
@@ -15,6 +15,7 @@ import net.aufdemrand.denizencore.objects.aH;
 import net.aufdemrand.denizencore.objects.dList;
 import net.aufdemrand.denizencore.scripts.ScriptEntry;
 import net.aufdemrand.denizencore.scripts.commands.AbstractCommand;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 
@@ -36,8 +37,8 @@ public class ToastCommand extends AbstractCommand {
             }
             else if (!scriptEntry.hasObject("icon")
                     && arg.matchesPrefix("icon", "i")
-                    && arg.matchesArgumentType(dMaterial.class)) {
-                scriptEntry.addObject("icon", arg.asType(dMaterial.class));
+                    && arg.matchesArgumentType(dItem.class)) {
+                scriptEntry.addObject("icon", arg.asType(dItem.class));
             }
             else if (!scriptEntry.hasObject("frame")
                     && arg.matchesPrefix("frame", "f")
@@ -66,7 +67,7 @@ public class ToastCommand extends AbstractCommand {
             }
         }
 
-        scriptEntry.defaultObject("icon", dMaterial.AIR);
+        scriptEntry.defaultObject("icon", new dItem(Material.AIR));
         scriptEntry.defaultObject("frame", new Element("TASK"));
 
     }
@@ -78,7 +79,7 @@ public class ToastCommand extends AbstractCommand {
     public void execute(ScriptEntry scriptEntry) throws CommandExecutionException {
         Element text = scriptEntry.getElement("text");
         Element frame = scriptEntry.getElement("frame");
-        dMaterial icon = scriptEntry.getdObject("icon");
+        dItem icon = scriptEntry.getdObject("icon");
         final List<dPlayer> targets = (List<dPlayer>) scriptEntry.getObject("targets");
 
         if (scriptEntry.dbCallShouldDebug()) {
@@ -87,7 +88,7 @@ public class ToastCommand extends AbstractCommand {
 
         final Advancement advancement = new Advancement(true,
                 new NamespacedKey(DenizenAPI.getCurrentInstance(), UUID.randomUUID().toString()), null,
-                icon.getMaterial(), icon.getData(), text.asString(), "", DEFAULT_BACKGROUND,
+                icon.getItemStack(), text.asString(), "", DEFAULT_BACKGROUND,
                 Advancement.Frame.valueOf(frame.asString().toUpperCase()), true, false, true, 0, 0);
 
         final AdvancementHelper advancementHelper = NMSHandler.getInstance().getAdvancementHelper();

--- a/v1_12_R1/src/main/java/net/aufdemrand/denizen/nms/helpers/AdvancementHelper_v1_12_R1.java
+++ b/v1_12_R1/src/main/java/net/aufdemrand/denizen/nms/helpers/AdvancementHelper_v1_12_R1.java
@@ -9,7 +9,6 @@ import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 import java.util.Collections;
 import java.util.Map;
@@ -110,8 +109,7 @@ public class AdvancementHelper_v1_12_R1 implements AdvancementHelper {
         Advancement parent = advancement.parent != null
                 ? AdvancementDataWorld.REGISTRY.advancements.get(asMinecraftKey(advancement.parent))
                 : null;
-        ItemStack bukkitIcon = new ItemStack(advancement.iconMaterial, 1, (short)0, advancement.iconData);
-        AdvancementDisplay display = new AdvancementDisplay(CraftItemStack.asNMSCopy(bukkitIcon),
+        AdvancementDisplay display = new AdvancementDisplay(CraftItemStack.asNMSCopy(advancement.icon),
                 new ChatComponentText(advancement.title), new ChatComponentText(advancement.description),
                 asMinecraftKey(advancement.background), AdvancementFrameType.valueOf(advancement.frame.name()),
                 advancement.toast, advancement.announceToChat, advancement.hidden);

--- a/v1_13_R2/src/main/java/net/aufdemrand/denizen/nms/helpers/AdvancementHelper_v1_13_R2.java
+++ b/v1_13_R2/src/main/java/net/aufdemrand/denizen/nms/helpers/AdvancementHelper_v1_13_R2.java
@@ -9,7 +9,6 @@ import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_13_R2.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 import java.util.Collections;
 import java.util.Map;
@@ -110,8 +109,7 @@ public class AdvancementHelper_v1_13_R2 implements AdvancementHelper {
         Advancement parent = advancement.parent != null
                 ? AdvancementDataWorld.REGISTRY.advancements.get(asMinecraftKey(advancement.parent))
                 : null;
-        ItemStack bukkitIcon = new ItemStack(advancement.iconMaterial, 1, (short)0, advancement.iconData);
-        AdvancementDisplay display = new AdvancementDisplay(CraftItemStack.asNMSCopy(bukkitIcon),
+        AdvancementDisplay display = new AdvancementDisplay(CraftItemStack.asNMSCopy(advancement.icon),
                 new ChatComponentText(advancement.title), new ChatComponentText(advancement.description),
                 asMinecraftKey(advancement.background), AdvancementFrameType.valueOf(advancement.frame.name()),
                 advancement.toast, advancement.announceToChat, advancement.hidden);


### PR DESCRIPTION
This fixes the recently added advancement/toast commands so they also work in 1.13+

It also changes each command to use dItem rather than dMaterial icons, allowing for more possibilities such as:

![image](https://user-images.githubusercontent.com/29823405/47350554-19b32c80-d684-11e8-92ce-f0261b2a6eca.png)
