### PR TITLE
Fix tab completion in 1.13

### DIFF
--- a/plugin/src/main/java/net/aufdemrand/denizen/Denizen.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/Denizen.java
@@ -902,6 +902,9 @@ public class Denizen extends JavaPlugin implements DenizenImplementation {
                 try {
                     DenizenCore.loadScripts();
 
+                    // Synchronize any script commands added while loading scripts.
+                    CommandScriptHelper.syncDenizenCommands();
+
                     // Load the saves.yml into memory
                     reloadSaves();
 

--- a/plugin/src/main/java/net/aufdemrand/denizen/DenizenCommandHandler.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/DenizenCommandHandler.java
@@ -3,6 +3,7 @@ package net.aufdemrand.denizen;
 import net.aufdemrand.denizen.objects.dLocation;
 import net.aufdemrand.denizen.objects.dPlayer;
 import net.aufdemrand.denizen.objects.notable.NotableManager;
+import net.aufdemrand.denizen.scripts.containers.core.CommandScriptHelper;
 import net.aufdemrand.denizen.scripts.containers.core.VersionScriptContainer;
 import net.aufdemrand.denizen.utilities.DenizenAPI;
 import net.aufdemrand.denizen.utilities.ScriptVersionChecker;
@@ -319,6 +320,7 @@ public class DenizenCommandHandler {
             DenizenCore.reloadScripts();
             denizen.notableManager().reloadNotables();
             denizen.reloadSaves();
+            CommandScriptHelper.syncDenizenCommands();
             Messaging.send(sender, "Denizen/saves.yml, Denizen/notables.yml, Denizen/config.yml, Denizen/scripts/..., and Denizen/externals/... reloaded from disk to memory.");
             if (ScriptHelper.hadError()) {
                 Messaging.sendError(sender, "There was an error loading your scripts, check the console for details!");
@@ -351,6 +353,7 @@ public class DenizenCommandHandler {
             }
             else if (args.getString(1).equalsIgnoreCase("scripts")) {
                 DenizenCore.reloadScripts();
+                CommandScriptHelper.syncDenizenCommands();
                 Messaging.send(sender, "Denizen/scripts/... reloaded from disk to memory.");
                 if (ScriptHelper.hadError()) {
                     Messaging.sendError(sender, "There was an error loading your scripts, check the console for details!");

--- a/plugin/src/main/java/net/aufdemrand/denizen/scripts/containers/core/CommandScriptHelper.java
+++ b/plugin/src/main/java/net/aufdemrand/denizen/scripts/containers/core/CommandScriptHelper.java
@@ -2,6 +2,8 @@ package net.aufdemrand.denizen.scripts.containers.core;
 
 import com.google.common.base.Predicate;
 import net.aufdemrand.denizen.Settings;
+import net.aufdemrand.denizen.nms.NMSHandler;
+import net.aufdemrand.denizen.nms.NMSVersion;
 import net.aufdemrand.denizen.utilities.DenizenAPI;
 import net.aufdemrand.denizen.utilities.DenizenAliasHelpTopic;
 import net.aufdemrand.denizen.utilities.DenizenCommand;
@@ -17,6 +19,7 @@ import org.bukkit.help.HelpTopic;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,6 +89,24 @@ public class CommandScriptHelper implements Listener {
             dB.echoError("Command scripts will not function!");
             //dB.echoError(e);
             hasCommandInformation = false;
+        }
+    }
+
+    /**
+     * In 1.13+, commands are also sent to players client-side via packets.
+     * We need to sync them for tab completion to work.
+     */
+    public static void syncDenizenCommands() {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_13_R2)) {
+            try {
+                final Server server = DenizenAPI.getCurrentInstance().getServer();
+                final Method syncMethod = server.getClass().getDeclaredMethod("syncCommands");
+                syncMethod.setAccessible(true);
+                syncMethod.invoke(server);
+            }
+            catch (Exception e) {
+                dB.echoError("Failed to synchronize server commands.");
+            }
         }
     }
 


### PR DESCRIPTION
Turns out everything was fine serverside, but players weren't receiving custom commands because we register them via reflection. Known commands are now bundled into a tree and sent to clients via a packet - we just have to sync that command tree on start or script reload.

Fixes some of the tab completion notes on our 1.13 issue: https://github.com/DenizenScript/Denizen-For-Bukkit/issues/1788